### PR TITLE
Feature/reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ you can utilize the bash scripts in the `bin/` directory.
     ```bash
     bash bin/destroy
     ```
+
+After running `bash bin/up` and everything has spun up,
+open a web browser and navigate to:
+`http://172.18.0.3/portainer`

--- a/bin/destroy
+++ b/bin/destroy
@@ -3,3 +3,4 @@
 docker stop portainer
 docker rm portainer
 docker volume rm dockerizeportainer_portainer_data
+docker network rm dockerizeportainer_portainer_network

--- a/bin/destroy
+++ b/bin/destroy
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker stop portainer
-docker rm portainer
+docker stop portainer portainer_nginx
+docker rm portainer portainer_nginx
 docker volume rm dockerizeportainer_portainer_data
 docker network rm dockerizeportainer_portainer_network

--- a/bin/destroy
+++ b/bin/destroy
@@ -2,5 +2,5 @@
 
 docker stop portainer portainer_nginx
 docker rm portainer portainer_nginx
-docker volume rm dockerizeportainer_portainer_data
-docker network rm dockerizeportainer_portainer_network
+docker volume rm dockerize-portainer_portainer_data
+docker network rm dockerize-portainer_portainer_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - 80:80
       - 443:443
     restart: always
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     networks:
       portainer_network:
         ipv4_address: 172.18.0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,16 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data
+    networks:
+      portainer_network:
+        ipv4_address: 172.18.0.10
 
 volumes:
   portainer_data:
+
+networks:
+  portainer_network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,18 @@ services:
       - portainer_data:/data
     networks:
       portainer_network:
-        ipv4_address: 172.18.0.10
+        ipv4_address: 172.18.0.2
+
+  nginx:
+    container_name: portainer_nginx
+    image: nginx
+    ports:
+      - 80:80
+      - 443:443
+    restart: always
+    networks:
+      portainer_network:
+        ipv4_address: 172.18.0.3
 
 volumes:
   portainer_data:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,29 @@
+upstream portainer {
+  server 172.18.0.2:9000;
+}
+
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name bletchleycloud.local;
+
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /portainer/ {
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_pass http://portainer/;
+  }
+
+  location /portainer/api/websocket/ {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_pass http://portainer/api/websocket/;
+  }
+}


### PR DESCRIPTION
This modifies the docker-compose to add an nginx reverse proxy and network subnet.  It also provides an nginx server configuration that allows you to hit the subnet ip to access portainer instead of the local ip.